### PR TITLE
Calojets and L1 bits in main root tree maker

### DIFF
--- a/data/json/README.md
+++ b/data/json/README.md
@@ -44,6 +44,9 @@ lumiSummary_crab_ParkingScoutingMonitor__Run2015D-PromptReco-v4__MINIAOD.json
 (CERN EOS) /eos/cms/store/group/phys_exotica/dijet/Dijet13TeVScouting/rootTrees_big/ParkingScoutingMonitor_Run2015D_Jan-12-2016_20160112_151048/ParkingScoutingMonitor/crab_ParkingScoutingMonitor__Run2015D-PromptReco-v4__MINIAOD/160112_211104/0000/
 (ROME T2) /pnfs/roma1.infn.it/data/cms/store/user/santanas/Dijet13TeVScouting/rootTrees_big/ParkingScoutingMonitor_Run2015D_v4_Jan-12-2016_20160112_151048/ (7 files not copied: )
 
+New version with calojet information included:
+(CERN EOS) /eos/cms/store/group/phys_exotica/dijet/Dijet13TeVScouting/rootTrees_big/CaloScouting/v1.1/ParkingScoutingMonitor/Run2015D/
+
 1746.320 /pb
 
 8185013 events
@@ -64,6 +67,27 @@ lumiSummary_crab_ScoutingPFCommissioning__Run2015D-v1__RAW.json
 1922.867 /pb
 
 19400055 events
+
+ScoutingCaloHT
+============
+
+1)
+
+/ScoutingCaloHT/Run2015D-v1/RAW
+
+(CERN EOS) eos/cms/store/group/phys_exotica/dijet/Dijet13TeVScouting/rootTrees_big/CaloScouting/v1.1/ScoutingCaloHT/Run2015D/
+
+
+ScoutingCaloCommissioning
+============
+
+1)
+
+/ScoutingCaloCommissioning/Run2015D-v1/RAW
+
+(CERN EOS) eos/cms/store/group/phys_exotica/dijet/Dijet13TeVScouting/rootTrees_big/CaloScouting/v1.1/ScoutingCaloCommissioning/Run2015D/
+
+
 
 ==================
 ======= MC =======

--- a/plugins/DijetScoutingTreeProducer.h
+++ b/plugins/DijetScoutingTreeProducer.h
@@ -18,6 +18,7 @@
 #include "DataFormats/Scouting/interface/ScoutingPFJet.h"
 #include "DataFormats/Scouting/interface/ScoutingPhoton.h"
 #include "DataFormats/Scouting/interface/ScoutingVertex.h"
+#include "DataFormats/Scouting/interface/ScoutingCaloJet.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
@@ -75,6 +76,11 @@ private:
     edm::EDGetTokenT<reco::VertexCollection> srcVrtxreco_;
     edm::EDGetTokenT<double> srcRhoreco_;
     edm::EDGetTokenT<pat::METCollection> srcMETreco_;
+    //For calo scouting
+    bool doCalo_;
+    edm::EDGetTokenT<ScoutingCaloJetCollection> srcJetsAK4calo_;
+    edm::EDGetTokenT<double> srcRhocalo_, srcMETcalo_;
+
     edm::Service<TFileService> fs_;
     TTree *outTree_;
 
@@ -93,6 +99,11 @@ private:
     float rhoreco_, metreco_, metrecoSig_, mhtAK4reco_, mhtAK4recoSig_;
     float htAK4_, mjjAK4_, dEtajjAK4_, dPhijjAK4_;
     float htAK4reco_, mjjAK4reco_, dEtajjAK4reco_, dPhijjAK4reco_;
+    //For calo scouting
+    int nJetsAK4calo_;
+    float rhocalo_, metcalo_, metcaloSig_, mhtAK4calo_, mhtAK4caloSig_;
+    float htAK4calo_, mjjAK4calo_, dEtajjAK4calo_, dPhijjAK4calo_;
+
     std::vector<bool> *triggerResult_;
 
     //---- jet and genJet variables --------------
@@ -109,6 +120,11 @@ private:
     std::vector<int> *idLAK4reco_, *idTAK4reco_, *chHadMultAK4reco_,
         *chMultAK4reco_, *neHadMultAK4reco_, *neMultAK4reco_, *phoMultAK4reco_;
     std::vector<float> *hf_hfAK4reco_, *hf_emfAK4reco_, *hofAK4reco_;
+    //For calo scouting
+    std::vector<float> *ptAK4calo_, *jecAK4calo_, *etaAK4calo_, *phiAK4calo_, *massAK4calo_,
+        *energyAK4calo_, *areaAK4calo_, *csvAK4calo_, *hadfAK4calo_, *emfAK4calo_;
+    std::vector<int> *idAK4calo_;
+    std::vector<float> *hf_hfAK4calo_, *hf_emfAK4calo_;
 };
 
 #endif

--- a/plugins/DijetScoutingTreeProducer.h
+++ b/plugins/DijetScoutingTreeProducer.h
@@ -31,6 +31,7 @@
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionEvaluator.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionParser.h"
+#include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
 
 // Root include files
 #include "TLorentzVector.h"
@@ -90,6 +91,13 @@ private:
     std::vector<std::string> vtriggerAlias_, vtriggerSelection_;
     std::vector<int> vtriggerDuplicates_;
     TH1F *triggerPassHisto_, *triggerNamesHisto_;
+    TH1F *l1PassHisto_, *l1NamesHisto_;
+    //---- L1 ----
+    bool doL1_;
+    L1GtUtils *l1GtUtils_;
+    std::vector<std::string> l1Seeds_;
+    edm::InputTag l1InputTag_;
+    std::vector<bool> *l1Result_;
     //---- output TREE variables ------
     //---- global event variables -----
     int   isData_, run_, evt_, nVtx_, lumi_;

--- a/prod/flat-data-monitor_cfg.py
+++ b/prod/flat-data-monitor_cfg.py
@@ -8,9 +8,9 @@ process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 
 ## ----------------- Global Tag ------------------
-#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
-
-#process.GlobalTag.globaltag = THISGLOBALTAG
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+#process.GlobalTag.globaltag = "74X_dataRun2_HLT_v1"
+process.GlobalTag.globaltag = THISGLOBALTAG
 
 
 #--------------------- Report and output ---------------------------
@@ -21,6 +21,7 @@ process.load('FWCore.MessageService.MessageLogger_cfi')
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 process.TFileService=cms.Service("TFileService",
+                                 #fileName=cms.string("monitor.root"),
                                  fileName=cms.string(THISROOTFILE),
                                  closeFileFast = cms.untracked.bool(True)
                                  )
@@ -58,6 +59,13 @@ process.source = cms.Source(
     )
 )
 
+#unpack L1 trigger results from RAW
+process.gtDigis = cms.EDProducer( "L1GlobalTriggerRawToDigi",
+    DaqGtFedId = cms.untracked.int32( 813 ),
+    DaqGtInputTag = cms.InputTag( "hltFEDSelectorL1" ),
+    UnpackBxInEvent = cms.int32( -1 ),
+    ActiveBoardsMask = cms.uint32( 0xffff )
+)
 
 
 ##-------------------- User analyzer  --------------------------------
@@ -78,6 +86,11 @@ process.dijetscouting = cms.EDAnalyzer(
     rhoreco     = cms.InputTag('fixedGridRhoFastjetAll'),
     metreco     = cms.InputTag('slimmedMETs'),
     vtxreco     = cms.InputTag('offlineSlimmedPrimaryVertices'),
+    # CaloScouting
+    doCalo      = cms.bool(True),
+    jetsAK4calo = cms.InputTag('hltScoutingCaloPacker'),
+    rhocalo     = cms.InputTag('hltScoutingCaloPacker:rho'),
+    metcalo     = cms.InputTag('hltScoutingCaloPacker:caloMetPt'),
 
     ## trigger ###################################
     triggerAlias = cms.vstring(
@@ -244,7 +257,12 @@ process.dijetscouting = cms.EDAnalyzer(
     L1corrAK4reco_DATA = cms.FileInPath('CMSDIJET/DijetScoutingRootTreeMaker/data/Summer15_25nsV3_DATA/Summer15_25nsV3_DATA_L1FastJet_AK4PFchs.txt'),
     L2corrAK4reco_DATA = cms.FileInPath('CMSDIJET/DijetScoutingRootTreeMaker/data/Summer15_25nsV3_DATA/Summer15_25nsV3_DATA_L2Relative_AK4PFchs.txt'),
     L3corrAK4reco_DATA = cms.FileInPath('CMSDIJET/DijetScoutingRootTreeMaker/data/Summer15_25nsV3_DATA/Summer15_25nsV3_DATA_L3Absolute_AK4PFchs.txt'),
-    ResCorrAK4reco_DATA = cms.FileInPath('CMSDIJET/DijetScoutingRootTreeMaker/data/Summer15_25nsV3_DATA/Summer15_25nsV3_DATA_L2L3Residual_AK4PFchs.txt')
+    ResCorrAK4reco_DATA = cms.FileInPath('CMSDIJET/DijetScoutingRootTreeMaker/data/Summer15_25nsV3_DATA/Summer15_25nsV3_DATA_L2L3Residual_AK4PFchs.txt'),
+
+    #L1 trigger info
+    doL1 = cms.bool(True),
+    l1Seeds = cms.vstring("L1_HTT125","L1_HTT150","L1_HTT175","L1_ZeroBias","L1_DoubleMu_10_3p5","L1_DoubleMu_12_5"),
+    l1InputTag = cms.InputTag("gtDigis","","RECO")
 )
 
 


### PR DESCRIPTION
This PR adds the following:
- Option to save HLT calojet information in DijetScoutingTreeProducer (enabled in the config for the monitor dataset)
- Option to save L1 bits (enabled in the config for the monitor dataset)
- New ntuple location information in data/json README file
