### PR TITLE
Port to 80x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Information: https://twiki.cern.ch/twiki/bin/viewauth/CMS/ExoDijet13TeV#Analysis
 Setup release:
 
 ```
-cmsrel CMSSW_7_4_15
-cd CMSSW_7_4_15/src/
+cmsrel CMSSW_8_0_7_patch2
+cd CMSSW_8_0_7_patch2/src/
 cmsenv
 ```
 
@@ -15,8 +15,6 @@ Clone and compile repository:
 
 ```
 git clone https://github.com/CMSDIJET/DijetScoutingRootTreeMaker.git CMSDIJET/DijetScoutingRootTreeMaker
-git fetch origin branch_74x:branch_74x
-git checkout branch_74x
 scram b -j4
 ```
 
@@ -28,3 +26,18 @@ cmsRun flat-data_cfg.py
 ```
 
 Use the configuration file `flat-data-monitor_cfg.py` to run over the ParkingScoutingMonitor datasets.
+
+
+
+
+In order to keep running in 74x replace the instructions above with:
+
+```
+cmsrel CMSSW_7_4_15
+cd CMSSW_7_4_15/src
+cmsenv
+git clone https://github.com/CMSDIJET/DijetScoutingRootTreeMaker.git CMSDIJET/DijetScoutingRootTreeMaker
+git fetch origin branch_74x:branch_74x
+git checkout branch_74x
+scram b -j4
+```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Clone and compile repository:
 
 ```
 git clone https://github.com/CMSDIJET/DijetScoutingRootTreeMaker.git CMSDIJET/DijetScoutingRootTreeMaker
-scram b
+git fetch origin branch_74x:branch_74x
+git checkout branch_74x
+scram b -j4
 ```
 
 Edit the configuration file `CMSDIJET/DijetScoutingRootTreeMaker/prod/flat-data_cfg.py` and then run with

--- a/plugins/BuildFile.xml
+++ b/plugins/BuildFile.xml
@@ -15,6 +15,7 @@
     <use name="FWCore/PluginManager"/>
     <use name="FWCore/ServiceRegistry"/>
     <use name="HLTrigger/HLTcore"/>
+    <use name="L1Trigger/L1TGlobal"/>
     <use name="CondFormats/DataRecord"/>
     <flags EDM_PLUGIN="1"/>
 </library>

--- a/plugins/DijetCaloScoutingTreeProducer.cc
+++ b/plugins/DijetCaloScoutingTreeProducer.cc
@@ -115,6 +115,18 @@ void DijetCaloScoutingTreeProducer::beginJob()
     for (unsigned i=0; i<vtriggerAlias_.size(); ++i) {
         triggerPassHisto_->Fill(vtriggerAlias_[i].c_str(), 0.0);
     }
+    l1NamesHisto_ = fs_->make<TH1F>("L1Names", "L1Names", 1, 0, 1);
+    l1NamesHisto_->SetCanExtend(TH1::kAllAxes);
+    for (unsigned i=0; i<l1Seeds_.size(); ++i) {
+      l1NamesHisto_->Fill(l1Seeds_[i].c_str(), 1);
+    }
+    l1PassHisto_ = fs_->make<TH1F>("L1Pass", "L1Pass", 1, 0, 1);
+    l1PassHisto_->SetCanExtend(TH1::kAllAxes);
+    l1PassHisto_->Fill("totalEvents", 0.0);
+    for (unsigned i=0; i<l1Seeds_.size(); ++i) {
+      l1PassHisto_->Fill(l1Seeds_[i].c_str(), 0.0);
+    }
+
 
     //--- book the tree -----------------------
     outTree_ = fs_->make<TTree>("events","events");
@@ -418,12 +430,18 @@ void DijetCaloScoutingTreeProducer::analyze(const Event& iEvent,
     }
 
     //-------------- L1 Info -----------------------------------
+    l1PassHisto_->Fill("totalEvents", 1);
     if (doL1_) {
         l1GtUtils_->retrieveL1(iEvent,iSetup,algToken_);
         for( unsigned int iseed = 0; iseed < l1Seeds_.size(); iseed++ ) {
   	    bool l1htbit = 0;
 	    l1GtUtils_->getFinalDecisionByName(l1Seeds_[iseed], l1htbit);
             l1Result_->push_back( l1htbit );
+	    //Fill histogram
+	    if (l1htbit) {
+	      l1PassHisto_->Fill(l1Seeds_[iseed].c_str(), 1);
+	    }
+
 	}
     }
     

--- a/plugins/DijetCaloScoutingTreeProducer.cc
+++ b/plugins/DijetCaloScoutingTreeProducer.cc
@@ -105,12 +105,12 @@ void DijetCaloScoutingTreeProducer::beginJob()
 {
     //--- book the trigger histograms ---------
     triggerNamesHisto_ = fs_->make<TH1F>("TriggerNames", "TriggerNames", 1, 0, 1);
-    triggerNamesHisto_->SetBit(TH1::kCanRebin);
+    triggerNamesHisto_->SetCanExtend(TH1::kAllAxes);
     for (unsigned i=0; i<vtriggerSelection_.size(); ++i) {
         triggerNamesHisto_->Fill(vtriggerSelection_[i].c_str(), 1);
     }
     triggerPassHisto_ = fs_->make<TH1F>("TriggerPass", "TriggerPass", 1, 0, 1);
-    triggerPassHisto_->SetBit(TH1::kCanRebin);
+    triggerPassHisto_->SetCanExtend(TH1::kAllAxes);
     triggerPassHisto_->Fill("totalEvents", 0.0);
     for (unsigned i=0; i<vtriggerAlias_.size(); ++i) {
         triggerPassHisto_->Fill(vtriggerAlias_[i].c_str(), 0.0);

--- a/plugins/DijetCaloScoutingTreeProducer.cc
+++ b/plugins/DijetCaloScoutingTreeProducer.cc
@@ -87,11 +87,14 @@ DijetCaloScoutingTreeProducer::DijetCaloScoutingTreeProducer(const ParameterSet&
     if (doL1_) {
         l1Seeds_ = cfg.getParameter<std::vector<std::string> >("l1Seeds");
         l1InputTag_ = cfg.getParameter<edm::InputTag>("l1InputTag");
-        l1GtUtils_ = new L1GtUtils();
+
+        //l1GtUtils_ = new L1GtUtils(cfg, consumesCollector(), true);
+	l1GtUtils_ = new L1GtUtils(cfg, consumesCollector(), true, *this, l1InputTag_, l1InputTag_, l1InputTag_);
     }
     else {
         l1Seeds_ = std::vector<std::string>();
         l1InputTag_ = edm::InputTag();
+
         l1GtUtils_ = 0;
     }
 }
@@ -414,11 +417,10 @@ void DijetCaloScoutingTreeProducer::analyze(const Event& iEvent,
 
     //-------------- L1 Info -----------------------------------
     if (doL1_) {
-        l1GtUtils_->getL1GtRunCache(iEvent, iSetup, true, false);
+        l1GtUtils_->getL1GtRunCache(iEvent, iSetup, true, true);
         int iErrorCode = -1;
         for( unsigned int iseed = 0; iseed < l1Seeds_.size(); iseed++ ) {
-            bool l1htbit = l1GtUtils_->decisionBeforeMask(iEvent, l1InputTag_, l1InputTag_, 
-                                                            l1Seeds_[iseed], iErrorCode);
+  	    bool l1htbit = l1GtUtils_->decisionBeforeMask(iEvent, l1Seeds_[iseed], iErrorCode);
             l1Result_->push_back( l1htbit );
             if (iErrorCode % 10 == 1) {
                 std::cout << "L1 seed " << l1Seeds_[iseed] << " not found!" << std::endl;

--- a/plugins/DijetCaloScoutingTreeProducer.h
+++ b/plugins/DijetCaloScoutingTreeProducer.h
@@ -27,7 +27,6 @@
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionEvaluator.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionParser.h"
-//#include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
 #include "L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h"
 
 

--- a/plugins/DijetCaloScoutingTreeProducer.h
+++ b/plugins/DijetCaloScoutingTreeProducer.h
@@ -27,7 +27,9 @@
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionEvaluator.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionParser.h"
-#include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
+//#include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
+#include "L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h"
+
 
 // Root include files
 #include "TLorentzVector.h"
@@ -42,6 +44,7 @@ public:
 
 private:
     virtual void beginJob();
+    virtual void beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup);
     virtual void analyze(edm::Event const& iEvent, edm::EventSetup const& iSetup);
     virtual void endJob();
 
@@ -93,9 +96,9 @@ private:
     std::vector<bool> *triggerResult_;
     //---- L1 ----
     bool doL1_;
-    L1GtUtils *l1GtUtils_;
+    edm::EDGetToken algToken_;
+    l1t::L1TGlobalUtil *l1GtUtils_;
     std::vector<std::string> l1Seeds_;
-    edm::InputTag l1InputTag_;
     std::vector<bool> *l1Result_;
 
     //---- jet and genJet variables --------------

--- a/plugins/DijetCaloScoutingTreeProducer.h
+++ b/plugins/DijetCaloScoutingTreeProducer.h
@@ -83,6 +83,7 @@ private:
     std::vector<std::string> vtriggerAlias_, vtriggerSelection_;
     std::vector<int> vtriggerDuplicates_;
     TH1F *triggerPassHisto_, *triggerNamesHisto_;
+    TH1F *l1PassHisto_, *l1NamesHisto_;
     //---- output TREE variables ------
     //---- global event variables -----
     int   isData_, run_, evt_, nVtx_, lumi_;

--- a/plugins/DijetMiniAODTreeProducer.cc
+++ b/plugins/DijetMiniAODTreeProducer.cc
@@ -86,12 +86,12 @@ void DijetMiniAODTreeProducer::beginJob()
 {
     //--- book the trigger histograms ---------
     triggerNamesHisto_ = fs_->make<TH1F>("TriggerNames", "TriggerNames", 1, 0, 1);
-    triggerNamesHisto_->SetBit(TH1::kCanRebin);
+    triggerNamesHisto_->SetCanExtend(TH1::kAllAxes);
     for (unsigned i=0; i<vtriggerSelection_.size(); ++i) {
         triggerNamesHisto_->Fill(vtriggerSelection_[i].c_str(), 1);
     }
     triggerPassHisto_ = fs_->make<TH1F>("TriggerPass", "TriggerPass", 1, 0, 1);
-    triggerPassHisto_->SetBit(TH1::kCanRebin);
+    triggerPassHisto_->SetCanExtend(TH1::kAllAxes);
     triggerPassHisto_->Fill("totalEvents", 0.0);
     for (unsigned i=0; i<vtriggerAlias_.size(); ++i) {
         triggerPassHisto_->Fill(vtriggerAlias_[i].c_str(), 0.0);

--- a/plugins/DijetScoutingTreeProducer.cc
+++ b/plugins/DijetScoutingTreeProducer.cc
@@ -96,12 +96,10 @@ DijetScoutingTreeProducer::DijetScoutingTreeProducer(const ParameterSet& cfg):
 
     if (doL1_) {
         l1Seeds_ = cfg.getParameter<std::vector<std::string> >("l1Seeds");
-        l1InputTag_ = cfg.getParameter<edm::InputTag>("l1InputTag");
-        l1GtUtils_ = new L1GtUtils();
+        l1GtUtils_ = new L1GtUtils(cfg, consumesCollector(), true);
     }
     else {
         l1Seeds_ = std::vector<std::string>();
-        l1InputTag_ = edm::InputTag();
         l1GtUtils_ = 0;
     }
 }
@@ -585,8 +583,7 @@ void DijetScoutingTreeProducer::analyze(const Event& iEvent,
         l1GtUtils_->getL1GtRunCache(iEvent, iSetup, true, false);
         int iErrorCode = -1;
         for( unsigned int iseed = 0; iseed < l1Seeds_.size(); iseed++ ) {
-            bool l1htbit = l1GtUtils_->decisionBeforeMask(iEvent, l1InputTag_, l1InputTag_, 
-                                                            l1Seeds_[iseed], iErrorCode);
+	    bool l1htbit = l1GtUtils_->decisionBeforeMask(iEvent, l1Seeds_[iseed], iErrorCode);
             l1Result_->push_back( l1htbit );
             //Fill histogram
             if (l1htbit) {

--- a/plugins/DijetScoutingTreeProducer.cc
+++ b/plugins/DijetScoutingTreeProducer.cc
@@ -115,23 +115,23 @@ void DijetScoutingTreeProducer::beginJob()
 {
     //--- book the trigger histograms ---------
     triggerNamesHisto_ = fs_->make<TH1F>("TriggerNames", "TriggerNames", 1, 0, 1);
-    triggerNamesHisto_->SetBit(TH1::kCanRebin);
+    triggerNamesHisto_->SetCanExtend(TH1::kAllAxes);
     for (unsigned i=0; i<vtriggerSelection_.size(); ++i) {
         triggerNamesHisto_->Fill(vtriggerSelection_[i].c_str(), 1);
     }
     triggerPassHisto_ = fs_->make<TH1F>("TriggerPass", "TriggerPass", 1, 0, 1);
-    triggerPassHisto_->SetBit(TH1::kCanRebin);
+    triggerPassHisto_->SetCanExtend(TH1::kAllAxes);
     triggerPassHisto_->Fill("totalEvents", 0.0);
     for (unsigned i=0; i<vtriggerAlias_.size(); ++i) {
         triggerPassHisto_->Fill(vtriggerAlias_[i].c_str(), 0.0);
     }
     l1NamesHisto_ = fs_->make<TH1F>("L1Names", "L1Names", 1, 0, 1);
-    l1NamesHisto_->SetBit(TH1::kCanRebin);
+    l1NamesHisto_->SetCanExtend(TH1::kAllAxes);
     for (unsigned i=0; i<l1Seeds_.size(); ++i) {
         l1NamesHisto_->Fill(l1Seeds_[i].c_str(), 1);
     }
     l1PassHisto_ = fs_->make<TH1F>("L1Pass", "L1Pass", 1, 0, 1);
-    l1PassHisto_->SetBit(TH1::kCanRebin);
+    l1PassHisto_->SetCanExtend(TH1::kAllAxes);
     l1PassHisto_->Fill("totalEvents", 0.0);
     for (unsigned i=0; i<l1Seeds_.size(); ++i) {
         l1PassHisto_->Fill(l1Seeds_[i].c_str(), 0.0);

--- a/plugins/DijetScoutingTreeProducer.h
+++ b/plugins/DijetScoutingTreeProducer.h
@@ -31,7 +31,8 @@
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionEvaluator.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionParser.h"
-#include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
+#include "L1Trigger/L1TGlobal/interface/L1TGlobalUtil.h"
+
 
 // Root include files
 #include "TLorentzVector.h"
@@ -94,9 +95,9 @@ private:
     TH1F *l1PassHisto_, *l1NamesHisto_;
     //---- L1 ----
     bool doL1_;
-    L1GtUtils *l1GtUtils_;
+    edm::EDGetToken algToken_;
+    l1t::L1TGlobalUtil *l1GtUtils_;
     std::vector<std::string> l1Seeds_;
-    edm::InputTag l1InputTag_;
     std::vector<bool> *l1Result_;
     //---- output TREE variables ------
     //---- global event variables -----

--- a/prod/flat-data-calo_cfg.py
+++ b/prod/flat-data-calo_cfg.py
@@ -19,7 +19,7 @@ process.GlobalTag.globaltag = "80X_dataRun2_HLT_v12"
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
-process.MessageLogger.cerr.FwkReport.reportEvery = 100
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 process.TFileService=cms.Service("TFileService",
                                  fileName=cms.string("dijetNtuple.root"),
@@ -41,14 +41,9 @@ process.source = cms.Source(
     )
 )
 
-#unpack trigger results from RAW
-#process.gtDigis = cms.EDProducer( "L1GlobalTriggerRawToDigi",
-#    DaqGtFedId = cms.untracked.int32( 813 ),
-#    DaqGtInputTag = cms.InputTag( "hltFEDSelectorL1" ),
-#    UnpackBxInEvent = cms.int32( -1 ),
-#    ActiveBoardsMask = cms.uint32( 0xffff )
-#)
-
+##--- l1 stage2 digis ---
+process.load("EventFilter.L1TRawToDigi.gtStage2Digis_cfi")
+process.gtStage2Digis.InputLabel = cms.InputTag( "hltFEDSelectorL1" )
 
 ##-------------------- User analyzer  --------------------------------
 
@@ -176,14 +171,10 @@ process.dijetscouting = cms.EDAnalyzer(
     L3corrAK4_DATA = cms.FileInPath('CMSDIJET/DijetScoutingRootTreeMaker/data/74X_dataRun2_HLT_v1/74X_dataRun2_HLT_v1_L3Absolute_AK4PFHLT.txt'),
 
     #L1 trigger info
-    doL1 = cms.bool(False),
-    l1InputTag = cms.InputTag("gtDigis","","jetToolbox"),
+    doL1 = cms.bool(True),
+    AlgInputTag = cms.InputTag("gtStage2Digis"),
 
-    #l1GtRecordInputTag = cms.InputTag("l1GtTriggerMenuLite"),
-    #l1GtReadoutRecordInputTag = cms.InputTag(""),
-    #l1GtTriggerMenuLiteInputTag =  cms.InputTag("l1GtTriggerMenuLite"),
-
-    l1Seeds = cms.vstring("L1_HTT125","L1_HTT150","L1_HTT175")
+    l1Seeds = cms.vstring("L1_HTT120","L1_HTT170","L1_HTT200")
 )
 
 

--- a/prod/flat-data-calo_cfg.py
+++ b/prod/flat-data-calo_cfg.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.Eras import eras
 
-process = cms.Process('jetToolbox')
+process = cms.Process('jetToolbox',eras.Run2_25ns)
 
 process.load('PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff')
 process.load('Configuration.EventContent.EventContent_cff')
@@ -9,7 +10,7 @@ process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cf
 
 ## ----------------- Global Tag ------------------
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
-process.GlobalTag.globaltag = "74X_dataRun2_HLT_v1"
+process.GlobalTag.globaltag = "80X_dataRun2_HLT_v12"
 #process.GlobalTag.globaltag = THISGLOBALTAG
 
 
@@ -18,7 +19,7 @@ process.GlobalTag.globaltag = "74X_dataRun2_HLT_v1"
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1000))
 
 process.load('FWCore.MessageService.MessageLogger_cfi')
-process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
 
 process.TFileService=cms.Service("TFileService",
                                  fileName=cms.string("dijetNtuple.root"),
@@ -36,17 +37,17 @@ process.options = cms.untracked.PSet(
 process.source = cms.Source(
     "PoolSource",
     fileNames = cms.untracked.vstring(
-        '/store/data/Run2015D/ScoutingCaloHT/RAW/v1/000/260/627/00000/46A705F8-0582-E511-A5BE-02163E014593.root',
+        '/store/user/duanders/ScoutingCaloHT_Run272798.root'
     )
 )
 
 #unpack trigger results from RAW
-process.gtDigis = cms.EDProducer( "L1GlobalTriggerRawToDigi",
-    DaqGtFedId = cms.untracked.int32( 813 ),
-    DaqGtInputTag = cms.InputTag( "hltFEDSelectorL1" ),
-    UnpackBxInEvent = cms.int32( -1 ),
-    ActiveBoardsMask = cms.uint32( 0xffff )
-)
+#process.gtDigis = cms.EDProducer( "L1GlobalTriggerRawToDigi",
+#    DaqGtFedId = cms.untracked.int32( 813 ),
+#    DaqGtInputTag = cms.InputTag( "hltFEDSelectorL1" ),
+#    UnpackBxInEvent = cms.int32( -1 ),
+#    ActiveBoardsMask = cms.uint32( 0xffff )
+#)
 
 
 ##-------------------- User analyzer  --------------------------------
@@ -66,8 +67,6 @@ process.dijetscouting = cms.EDAnalyzer(
     triggerAlias = cms.vstring(
         # Scouting
         'CaloJet40_CaloScouting_PFScouting', 
-        'CaloJet40_CaloScouting_PFScouting', 
-        'L1HTT_CaloScouting_PFScouting', 
         'L1HTT_CaloScouting_PFScouting', 
         'CaloScoutingHT250', 
         # RECO 
@@ -88,23 +87,17 @@ process.dijetscouting = cms.EDAnalyzer(
         'HT2000',
         'HT2500',
         'Mu45Eta2p1',
-        'AK8DiPFJet280200TrimMass30Btag',
-        'AK8PFHT600TriMass50Btag',
         'AK8PFHT700TriMass50',
         'AK8PFJet360TrimMass50',
         'CaloJet500NoJetID',
         'DiPFJetAve300HFJEC',
         'DiPFJetAve500',
-        'PFHT400SixJet30Btag',
-        'PFHT450SixJet40Btag',
         'PFHT750FourJetPt50',
         'QuadPFJetVBF'
     ),
     triggerSelection = cms.vstring(
         # Scouting
-        'DST_CaloJet40_CaloScouting_v*',
         'DST_CaloJet40_CaloScouting_PFScouting_v*',
-        'DST_L1HTT125ORHTT150ORHTT175_CaloScouting_v*',
         'DST_L1HTT_CaloScouting_PFScouting_v*',
         'DST_HT250_CaloScouting_v*',
         # RECO
@@ -125,15 +118,11 @@ process.dijetscouting = cms.EDAnalyzer(
         'HLT_HT2000_v*',
         'HLT_HT2500_v*',
         'HLT_Mu45_eta2p1_v*',
-        'HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p45_v*',
-        'HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV0p45_v*',
         'HLT_AK8PFHT700_TrimR0p1PT0p03Mass50_v*',
         'HLT_AK8PFJet360_TrimMass30_v*',
         'HLT_CaloJet500_NoJetID_v*',
         'HLT_DiPFJetAve300_HFJEC_v*',
         'HLT_DiPFJetAve500_v*',
-        'HLT_PFHT400_SixJet30_BTagCSV0p55_2PFBTagCSV0p72_v*',
-        'HLT_PFHT450_SixJet40_PFBTagCSV0p72_v*',
         'HLT_PFHT750_4JetPt50_v*',
         'HLT_QuadPFJet_VBF_v*'
     ),
@@ -141,10 +130,8 @@ process.dijetscouting = cms.EDAnalyzer(
         ## If >0, trigger result will be ORed with result from the previous
         ## trigger rather than being push_backed
         # Scouting
-        0, # CaloJet40_CaloScouting
-        1, # CaloJet40_CaloScouting_PFScouting
-        0, # L1HTT_CaloScouting
-        1, # L1HTT_CaloScouting_PFScouting
+        0, # CaloJet40_CaloScouting_PFScouting
+        0, # L1HTT_CaloScouting_PFScouting
         0, # CaloScoutingHT250
         # RECO
         0, # PFHT800
@@ -164,15 +151,11 @@ process.dijetscouting = cms.EDAnalyzer(
         0, # HT2000
         0, # HT2500
         0, # Mu45Eta2p1
-        0, # AK8DiPFJet280200TrimMass30Btag
-        0, # AK8PFHT600TriMass50Btag
         0, # AK8PFHT700TriMass50
         0, # AK8PFJet360TrimMass50
         0, # CaloJet500NoJetID
         0, # DiPFJetAve300HFJEC
         0, # DiPFJetAve500
-        0, # PFHT400SixJet30Btag
-        0, # PFHT450SixJet40Btag
         0, # PFHT750FourJetPt50
         0  # QuadPFJetVBF'
     ),
@@ -193,12 +176,16 @@ process.dijetscouting = cms.EDAnalyzer(
     L3corrAK4_DATA = cms.FileInPath('CMSDIJET/DijetScoutingRootTreeMaker/data/74X_dataRun2_HLT_v1/74X_dataRun2_HLT_v1_L3Absolute_AK4PFHLT.txt'),
 
     #L1 trigger info
-    doL1 = cms.bool(True),
-    l1Seeds = cms.vstring("L1_HTT125","L1_HTT150","L1_HTT175"),
-    l1InputTag = cms.InputTag("gtDigis","","jetToolbox")
+    doL1 = cms.bool(False),
+    l1InputTag = cms.InputTag("gtDigis","","jetToolbox"),
+
+    #l1GtRecordInputTag = cms.InputTag("l1GtTriggerMenuLite"),
+    #l1GtReadoutRecordInputTag = cms.InputTag(""),
+    #l1GtTriggerMenuLiteInputTag =  cms.InputTag("l1GtTriggerMenuLite"),
+
+    l1Seeds = cms.vstring("L1_HTT125","L1_HTT150","L1_HTT175")
 )
 
 
 # ------------------ path --------------------------
-
 process.p = cms.Path(process.dijetscouting)

--- a/prod/flat-data_cfg.py
+++ b/prod/flat-data_cfg.py
@@ -61,6 +61,9 @@ process.source = cms.Source(
     )
 )
 
+##--- l1 stage2 digis ---
+process.load("EventFilter.L1TRawToDigi.gtStage2Digis_cfi")
+process.gtStage2Digis.InputLabel = cms.InputTag( "hltFEDSelectorL1" )
 
 
 ##-------------------- User analyzer  --------------------------------
@@ -240,6 +243,13 @@ process.dijetscouting = cms.EDAnalyzer(
     L1corrAK4_DATA = cms.FileInPath('CMSDIJET/DijetScoutingRootTreeMaker/data/74X_dataRun2_HLT_v1/74X_dataRun2_HLT_v1_L1FastJet_AK4PFHLT.txt'),
     L2corrAK4_DATA = cms.FileInPath('CMSDIJET/DijetScoutingRootTreeMaker/data/74X_dataRun2_HLT_v1/74X_dataRun2_HLT_v1_L2Relative_AK4PFHLT.txt'),
     L3corrAK4_DATA = cms.FileInPath('CMSDIJET/DijetScoutingRootTreeMaker/data/74X_dataRun2_HLT_v1/74X_dataRun2_HLT_v1_L3Absolute_AK4PFHLT.txt')
+
+    #L1 trigger info                                                                                                                                                                         
+    doL1 = cms.bool(True),
+    AlgInputTag = cms.InputTag("gtStage2Digis"),
+
+    l1Seeds = cms.vstring("L1_HTT120","L1_HTT170","L1_HTT200")
+
 )
 
 


### PR DESCRIPTION
this PR brings the needed changes to the PF and Calo scouting ntuplizers to run on 2016 data. main changes are:
- update the l1 part in order to access the l1tStage2 information
- updates to the histograms to be ROOT6 compliant

the code is tested for the DijetCaloScoutingTreeProducer. still to be done:
- test the DijetScoutingTreeProducer.cc
- update the HLT and L1 algos to reflect the current menu
