### PR TITLE
add btag info to the calo scouting ntuples

### DIFF
--- a/plugins/DijetCaloScoutingTreeProducer.cc
+++ b/plugins/DijetCaloScoutingTreeProducer.cc
@@ -551,7 +551,7 @@ void DijetCaloScoutingTreeProducer::analyze(const Event& iEvent,
             massAK4_          ->push_back(ijet->m()*jecFactorsAK4.at(*i));
             energyAK4_        ->push_back(jet_energy*jecFactorsAK4.at(*i));
             areaAK4_          ->push_back(ijet->jetArea());
-            csvAK4_           ->push_back(-1);
+            csvAK4_           ->push_back(ijet->btagDiscriminator());
             idAK4_            ->push_back(id);
         }
     }

--- a/prod/flat-data-calo_cfg.py
+++ b/prod/flat-data-calo_cfg.py
@@ -54,7 +54,7 @@ if variables.local == True:
 process.source = cms.Source(
     "PoolSource",
     fileNames = cms.untracked.vstring(
-        '/store/data/Run2016B/ScoutingCaloHT/RAW/v1/000/272/784/00000/5891409E-4A14-E611-98FE-02163E01393D.root' #(2016B data)
+        '/store/data/Run2016C/ScoutingCaloHT/RAW/v2/000/276/095/00000/A8255F4A-3E3F-E611-81C7-02163E0146CA.root' #2016C data
     )
 )
 


### PR DESCRIPTION
this is needed to store the btag info in the calo scouting ntuples for runs after the last TS.
changes should be backward compatible
